### PR TITLE
Fix updating bug.

### DIFF
--- a/8chRelay.indigoPlugin/Contents/Info.plist
+++ b/8chRelay.indigoPlugin/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>0.1.8</string>
+	<string>0.1.11</string>
 	<key>ServerApiVersion</key>
 	<string>2.0</string>
 	<key>IwsApiVersion</key>


### PR DESCRIPTION
This contribution fixes a problem with the update routine. It seems to always update devices to off even when they're on. It also removes updates for duplicate host/post combos by using `set()`. The bug is fixed by setting all text to upper case and matching values "case insensitive." The script was originally looking for `Relayon` but the text was `relayon`.